### PR TITLE
fix: override Payment Reconciliation account filter for Student party type

### DIFF
--- a/edu_tz/hooks.py
+++ b/edu_tz/hooks.py
@@ -33,7 +33,9 @@ app_license = "MIT"
 # page_js = {"page" : "public/js/file.js"}
 
 # include js in doctype views
-# doctype_js = {"doctype" : "public/js/doctype.js"}
+doctype_js = {
+    "Payment Reconciliation": "public/js/payment_reconciliation.js",
+}
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}
 # doctype_calendar_js = {"doctype" : "public/js/doctype_calendar.js"}

--- a/edu_tz/public/js/payment_reconciliation.js
+++ b/edu_tz/public/js/payment_reconciliation.js
@@ -1,11 +1,7 @@
-// edu_tz override for Payment Reconciliation
-// Fixes root_type filter on receivable_payable_account to correctly treat
-// ALL "Receivable" party types (e.g. Customer, Student) as "Asset",
-// not just "Customer" as ERPNext core hard-codes.
-// See: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.js L30
-
 frappe.ui.form.on("Payment Reconciliation", {
-	onload: function (frm) {
+	refresh: function (frm) {
+		// Override ERPNext core filter which hard-codes only "Customer" → Asset.
+		// Student (and any future Receivable party type) also needs Asset accounts.
 		frm.set_query("receivable_payable_account", () => {
 			return {
 				filters: {

--- a/edu_tz/public/js/payment_reconciliation.js
+++ b/edu_tz/public/js/payment_reconciliation.js
@@ -1,0 +1,23 @@
+// edu_tz override for Payment Reconciliation
+// Fixes root_type filter on receivable_payable_account to correctly treat
+// ALL "Receivable" party types (e.g. Customer, Student) as "Asset",
+// not just "Customer" as ERPNext core hard-codes.
+// See: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.js L30
+
+frappe.ui.form.on("Payment Reconciliation", {
+	onload: function (frm) {
+		frm.set_query("receivable_payable_account", () => {
+			return {
+				filters: {
+					company: frm.doc.company,
+					is_group: 0,
+					account_type: frappe.boot.party_account_types[frm.doc.party_type],
+					root_type:
+						frappe.boot.party_account_types[frm.doc.party_type] == "Receivable"
+							? "Asset"
+							: "Liability",
+				},
+			};
+		});
+	},
+});


### PR DESCRIPTION
ERPNext core hard-codes root_type = "Asset" only when party_type ==
"Customer", causing the Student party type to incorrectly filter the
Receivable/Payable Account field to Liability accounts. This hides
Asset-root receivable accounts like "Debtors - SHMPS" from the dropdown.
Fix via edu_tz doctype_js hook (non-invasive, preserves upstream erpnext):
- Add public/js/payment_reconciliation.js with a refresh event override
  that derives root_type dynamically from frappe.boot.party_account_types:
  any party type with account_type="Receivable" → Asset, else Liability
- Register the override in hooks.py via doctype_js
The refresh event is used instead of onload because ERPNext's class
controller (extend_cscript) executes its onload() after frappe.ui.form.on
onload handlers, which would overwrite the override. Using refresh ensures
our set_query runs last and persists.
Tested: "Debtors - SHMPS" (Asset, Receivable) now appears correctly in
the dropdown when Party Type = Student.